### PR TITLE
fix(migrate): add initial state migration

### DIFF
--- a/migrations/versions/27833deaf81f_add_idp.py
+++ b/migrations/versions/27833deaf81f_add_idp.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "27833deaf81f"
-down_revision = None
+down_revision = "a38a346e6ded"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/a38a346e6ded_create_refresh_token_table.py
+++ b/migrations/versions/a38a346e6ded_create_refresh_token_table.py
@@ -1,0 +1,42 @@
+"""Create refresh_token table
+
+Revision ID: a38a346e6ded
+Revises: 
+Create Date: 2020-03-15 19:26:18.544300
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a38a346e6ded"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # check whether the `refresh_token` table already exists. We should
+    # not try to re-create the table in deployments whose DB was created
+    # before this "initial state" migration code was added.
+    conn = op.get_bind()
+    inspector = sa.engine.reflection.Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+    if "refresh_token" in tables:
+        return
+
+    op.create_table(
+        "refresh_token",
+        sa.Column("token", sa.VARCHAR(), nullable=False),
+        sa.Column("jti", sa.VARCHAR(), nullable=False),
+        sa.Column("username", sa.VARCHAR(), nullable=False),
+        sa.Column("userid", sa.VARCHAR(), nullable=False),
+        sa.Column("expires", sa.BIGINT(), nullable=False),
+        sa.PrimaryKeyConstraint("token", name="refresh_token_pkey"),
+        sa.UniqueConstraint("jti", name="refresh_token_jti_key"),
+    )
+
+
+def downgrade():
+    op.drop_table("refresh_token")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,15 +42,11 @@ def app():
 
 def setup_test_database():
     """
-    When running tests locally, we need to update the existing DB to
-    the latest version.
-    But in automated tests, a new DB is created from the latest models
-    so there is no need to migrate (and alembic fails when trying).
+    Update the test DB to the latest version. The migration code is able to
+    handle both updating an existing, pre-migration code DB (local tests)
+    and creating a new DB (automated tests)
     """
-    try:
-        alembic_main(["--raiseerr", "upgrade", "head"])
-    except SQLAlchemyError as e:
-        print("Skipping test DB migration: {}".format(e))
+    alembic_main(["--raiseerr", "upgrade", "head"])
 
 
 @pytest.fixture(scope="function")

--- a/wts/api.py
+++ b/wts/api.py
@@ -124,7 +124,6 @@ def _setup(app):
     app.logger.info("Set up OIDC clients: {}".format(list(app.oauth2_clients.keys())))
     setup_plugins(app)
     db.init_app(app)
-    Base.metadata.create_all(bind=db.engine)
     app.register_blueprint(oauth2.blueprint, url_prefix="/oauth2")
     app.register_blueprint(tokens.blueprint, url_prefix="/token")
     app.register_blueprint(external_oidc.blueprint, url_prefix="/external_oidc")


### PR DESCRIPTION
Fix issue for new deployments when [this code](https://github.com/uc-cdis/cloud-automation/pull/1128/files#diff-6d8dc692b19642f66af6e83ea6b54cec) tries to add a column to a table that doesn't exist during migration `27833deaf81f`

### Improvements
- Add initial state migration so that Alembic can be used to create a new WTS DB
