### PR TITLE
chore(release): Install g++ due to pip install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV appname=wts
 
 RUN apk update \
     && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \
-    && apk add linux-headers musl-dev gcc \
+    && apk add linux-headers musl-dev gcc g++ \
     && apk add curl bash git vim
 
 COPY . /$appname


### PR DESCRIPTION
Avoid this error:
```
[pipenv.exceptions.InstallError]: gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g
 -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -Isrc/greenlet/
  -I/usr/local/include/python3.6m -c src/greenlet/tests/_test_extension_cpp.cpp 
  -o build/temp.linux-x86_64-3.6/src/greenlet/tests/_test_extension_cpp.o
3/29/2021, 6:31:02 PM[pipenv.exceptions.InstallError]: gcc: error trying to exec 'cc1plus': execvp: No such file or directory
3/29/2021, 6:31:02 PM[pipenv.exceptions.InstallError]: error: command 'gcc' failed with exit status 1
```

### Bug Fixes
- Fix image build failures caused by the absence of g++