### PR TITLE
Dockerfile: don't lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /$appname
 
 RUN python -m pip install --upgrade pip \
     && pip install pipenv \
-    && pipenv lock \
     && python -m pipenv install --system --deploy \
     && pip freeze
 


### PR DESCRIPTION
Locking during the image build results in errors and should not be necessary