### PR TITLE
BRH 480

### DIFF
--- a/wts/blueprints/aggregate.py
+++ b/wts/blueprints/aggregate.py
@@ -62,6 +62,8 @@ async def get_aggregate_response(endpoint):
             flask.current_app.config["OIDC"][rt.idp]["commons_hostname"]: rt
             for rt in refresh_tokens
         }
+        # Release the db session as it is no longer needed in this call
+        db.session.close()
         access_tokens = await asyncio.gather(
             *[async_get_access_token(rt) for rt in refresh_tokens.values()]
         )


### PR DESCRIPTION
Jira Ticket: https://ctds-planx.atlassian.net/browse/BRH-480

Explanation:

We are reading the tokens from the DB at the beginning and then went on to do potentially large number of async calls afterwards. The db session is not released until the function call is complete and is unnecessarily kept for the function call as there is no subsequent use of the db. This delayed release of db connection causes the db connection pool to fill up and subsequent db reads gets rejected and eventually crashes the wts service.

The solution is to call db.session.close() to release db session after it is no longer needed.

### Bug Fixes
Manually release unneeded db session to free up connection pool to prevent crashes


