### PR TITLE
Fix: external_OIDC trailing slash issue

### DIFF
--- a/wts/blueprints/external_oidc.py
+++ b/wts/blueprints/external_oidc.py
@@ -9,13 +9,13 @@ from ..utils import get_config_var, get_oauth_client
 
 blueprint = flask.Blueprint("external_oidc", __name__)
 
-blueprint.route("")
-
 external_oidc_cache = {}
+blueprint.route("")
 
 
 # this is called every 10 sec by the Gen3Fuse sidecar
-@blueprint.route("", methods=["GET"])
+
+
 @blueprint.route("/", methods=["GET"])
 def get_external_oidc():
     """

--- a/wts/blueprints/external_oidc.py
+++ b/wts/blueprints/external_oidc.py
@@ -9,13 +9,13 @@ from ..utils import get_config_var, get_oauth_client
 
 blueprint = flask.Blueprint("external_oidc", __name__)
 
-external_oidc_cache = {}
 blueprint.route("")
+
+external_oidc_cache = {}
 
 
 # this is called every 10 sec by the Gen3Fuse sidecar
-
-
+@blueprint.route("", methods=["GET"])
 @blueprint.route("/", methods=["GET"])
 def get_external_oidc():
     """

--- a/wts/blueprints/external_oidc.py
+++ b/wts/blueprints/external_oidc.py
@@ -15,6 +15,7 @@ external_oidc_cache = {}
 
 
 # this is called every 10 sec by the Gen3Fuse sidecar
+@blueprint.route("", methods=["GET"])
 @blueprint.route("/", methods=["GET"])
 def get_external_oidc():
     """


### PR DESCRIPTION
Jira Ticket: [BRH-610](https://ctds-planx.atlassian.net/browse/BRH-610)

### Improvements
* Now users can get `external_oidc` response regardless of the  trailing slash i.e,  both `/wts/external_oidc` and `/wts/external_oidc/` are accepted

[BRH-610]: https://ctds-planx.atlassian.net/browse/BRH-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ