### PR TITLE
Fix docs and tests for 'id_token_username_field'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Two methods exist for authenticating a request to the `/token` endpoint:
                         "idp": "keycloak",
                         "auth_url": "auth/realms/xyz/protocol/openid-connect/auth",
                         "token_url": "auth/realms/xyz/protocol/openid-connect/token",
-                        "id_token_username": "email",
+                        "id_token_username_field": "email",
                         "scope": "openid profile offline_access"
                    }
                 }
@@ -105,9 +105,9 @@ Note that IDP IDs (`other-google` and `other-orcid` in the example above) must b
 Also note that the OIDC clients you create must be granted `read-storage` access to all the data in the external
 Data Commons via the data-commons' `user.yaml`.
 
-The `id_token_username` property for OIDC clients can be configured with `.` in between strings for a nested username inside a token.
+The `id_token_username_field` property for OIDC clients can be configured with `.` in between strings for a nested username inside a token.
 For example if the token jwt has username encoded in the json as `token["context"]["user"]["name"]`:
-We can write this in the parameters as `"id_token_username": "context.user.name"`.
+We can write this in the parameters as `"id_token_username_field": "context.user.name"`.
 If nothing is specified, for a fence client the default is `"context.user.name"`, for a non-fence client the default is `"email"`.
 
 

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -314,7 +314,7 @@ def test_app_config(app):
         app.config["OIDC"]["externaldata-keycloak"]["authorize_url"]
         == "https://external.data.repository/auth/realms/xyz/protocol/openid-connect/auth"
     )
-    assert app.config["OIDC"]["externaldata-keycloak"]["username_field"] == "email"
+    assert app.config["OIDC"]["externaldata-keycloak"]["username_field"] == "user.email"
     assert (
         app.config["OIDC"]["default"]["redirect_uri"]
         == "https://test.workspace.planx-pla.net/wts/oauth2/authorize"

--- a/tests/test_settings.json
+++ b/tests/test_settings.json
@@ -34,7 +34,7 @@
                         "idp": "keycloak",
                         "auth_url": "auth/realms/xyz/protocol/openid-connect/auth",
                         "token_url": "auth/realms/xyz/protocol/openid-connect/token",
-                        "id_token_username": "email",
+                        "id_token_username_field": "user.email",
                         "scope": "openid profile offline_access"
                    }
                 }


### PR DESCRIPTION
The field is "id_token_username_field" (see [here](https://github.com/uc-cdis/workspace-token-service/blob/2025.03/wts/api.py#L94)) but was called "id_token_username" in the documentation and the tests. The tests still passed because the tested value was the same as the default - "email".

### Improvements
- Fix the documentation and tests to mention the right configuration field name, "id_token_username_field", instead of "id_token_username"
