### PR TITLE
Fix missing JWT ID handling in refresh token creation

### DIFF
--- a/wts/resources/oauth2.py
+++ b/wts/resources/oauth2.py
@@ -2,6 +2,7 @@ from authlib.common.errors import AuthlibBaseError
 from datetime import datetime
 import flask
 from jose import jwt
+import time
 
 from authutils.user import current_user
 from cdiserrors import AuthError

--- a/wts/resources/oauth2.py
+++ b/wts/resources/oauth2.py
@@ -2,7 +2,7 @@ from authlib.common.errors import AuthlibBaseError
 from datetime import datetime
 import flask
 from jose import jwt
-import time
+import uuid
 
 from authutils.user import current_user
 from cdiserrors import AuthError
@@ -109,11 +109,18 @@ def refresh_refresh_token(tokens, idp, username_field):
             idp_username, idp, username
         )
     )
+    jti_value = content.get("jti")
+    if jti_value is None:
+        jti_value = str(uuid.uuid4())
+        flask.current_app.logger.warning(
+            f"Missing 'jti' field in token response for user {userid}. Generated UUID: {jti_value}"
+        )
+
     new_token = RefreshToken(
         token=refresh_token,
         userid=userid,
         username=username,
-        jti=content.get("jti", f"{userid}_{int(time.time())}"),  # Generate a custom jti if missing
+        jti=jti_value
         expires=content["exp"],
         idp=idp,
     )

--- a/wts/resources/oauth2.py
+++ b/wts/resources/oauth2.py
@@ -120,7 +120,7 @@ def refresh_refresh_token(tokens, idp, username_field):
         token=refresh_token,
         userid=userid,
         username=username,
-        jti=jti_value
+        jti=jti_value,
         expires=content["exp"],
         idp=idp,
     )

--- a/wts/resources/oauth2.py
+++ b/wts/resources/oauth2.py
@@ -112,7 +112,7 @@ def refresh_refresh_token(tokens, idp, username_field):
         token=refresh_token,
         userid=userid,
         username=username,
-        jti=content["jti"],
+        jti=content.get("jti", f"{userid}_{int(time.time())}"),  # Generate a custom jti if missing
         expires=content["exp"],
         idp=idp,
     )

--- a/wts/resources/oauth2.py
+++ b/wts/resources/oauth2.py
@@ -113,7 +113,7 @@ def refresh_refresh_token(tokens, idp, username_field):
     if jti_value is None:
         jti_value = str(uuid.uuid4())
         flask.current_app.logger.warning(
-            f"Missing 'jti' field in token response for user {userid}. Generated UUID: {jti_value}"
+            f"Missing 'jti' field in token response for user {userid}. Generated UUID: {jti_value} and used as 'jti' in our db. Note that the token issuer is not directly made aware of this association."
         )
 
     new_token = RefreshToken(


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Fixed KeyError when handling token responses without 'jti' field
- Added fallback UUID generation for missing JWT IDs
- Added warning logs when JTI field is missing from token response
- Improved error handling in refresh token creation process


### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
